### PR TITLE
Indispensable pour sécuriser les appels API

### DIFF
--- a/frontend/src/app/interceptors/auth.interceptor.ts
+++ b/frontend/src/app/interceptors/auth.interceptor.ts
@@ -1,0 +1,22 @@
+import {HttpInterceptorFn} from '@angular/common/http';
+import {inject} from '@angular/core';
+import {AuthService} from '../services/auth.service';
+
+export const authInterceptor: HttpInterceptorFn = (req, next) => {
+  const authService = inject(AuthService);
+  const token = authService.getToken();
+
+  // si pas de token → on laisse passer la requête telle quelle
+  if (!token) {
+    return next(req);
+  }
+
+  // on clone la requête et on ajoute le header Authorization
+  const clonedReq = req.clone({
+    setHeaders: {
+      Authorization: `Bearer ${token}`
+    }
+  });
+
+  return next(clonedReq);
+};


### PR DESCRIPTION
Rôle :
Intercepte toutes les requêtes HTTP
Ajoute automatiquement :
token JWT
headers

Indispensable pour sécuriser les appels API